### PR TITLE
Formatting fixes

### DIFF
--- a/_episodes_rmd/02-raster-plot.Rmd
+++ b/_episodes_rmd/02-raster-plot.Rmd
@@ -10,7 +10,9 @@ objectives:
 - "Build customized plots for a single band raster using the `ggplot2` package."
 - "Layer a raster dataset on top of a hillshade to create an elegant basemap."
 keypoints:
-- ""
+- "Continuous data ranges can be grouped into categories using `mutate()` and `cut()`."
+- "Use built-in `terrain.colors()` or set your prefered color scheme manually."
+- "Layer rasters on top of one another by using the `alpha` aesthetic."
 ---
 
 ```{r setup, echo=FALSE}

--- a/_episodes_rmd/03-raster-reproject-in-r.Rmd
+++ b/_episodes_rmd/03-raster-reproject-in-r.Rmd
@@ -219,7 +219,7 @@ These two resolutions are different, but they're representing the same data. We 
 newly reprojected raster to be 1m x 1m resolution by adding a line of code
 (`res=`) within the `projectRaster()` function.
 
-``` {r reproject-assign-resolution }
+```{r reproject-assign-resolution}
 DTM_hill_UTMZ18N_HARV <- projectRaster(DTM_hill_HARV,
                                   crs = crs(DTM_HARV),
                                   res = 1)
@@ -243,15 +243,12 @@ We can now create a plot of this data.
 
 ```{r plot-projected-raster}
 ggplot() +
+       geom_raster(data = DTM_HARV_df , 
+             aes(x = x, y = y, 
+                  fill = HARV_dtmCrop)) + 
      geom_raster(data = DTM_hill_HARV_2_df, 
                  aes(x = x, y = y, 
-                   alpha = HARV_DTMhill_WGS84)
-                 ) +
-     geom_raster(data = DTM_HARV_df , 
-             aes(x = x, y = y, 
-                  fill = HARV_dtmCrop,
-                  alpha=0.8)
-             ) + 
+                   alpha = HARV_DTMhill_WGS84)) +
      scale_fill_gradientn(name = "Elevation", colors = terrain.colors(10))
 ```
 
@@ -266,9 +263,9 @@ hillshade to produce a nice looking, textured map!
 > Reproject the data as necessary to make things line up!
 > > ## Answers
 > > ```{r challenge-code-reprojection, echo=TRUE}
-> > # import DTM
+> > # import DSM
 > > DSM_SJER <- raster("data/NEON-DS-Airborne-Remote-Sensing/SJER/DSM/SJER_dsmCrop.tif")
-> > # import DTM hillshade
+> > # import DSM hillshade
 > > DSM_hill_SJER_WGS <-
 > > raster("data/NEON-DS-Airborne-Remote-Sensing/SJER/DSM/SJER_DSMhill_WGS84.tif")
 > > 

--- a/_episodes_rmd/04-raster-calculations-in-r.Rmd
+++ b/_episodes_rmd/04-raster-calculations-in-r.Rmd
@@ -38,6 +38,16 @@ DSM_HARV_df <- raster::as.data.frame(DSM_HARV, xy = TRUE)
 DTM_HARV <- raster("data/NEON-DS-Airborne-Remote-Sensing/HARV/DTM/HARV_dtmCrop.tif")
 
 DTM_HARV_df <- raster::as.data.frame(DTM_HARV, xy = TRUE)
+
+# DSM data for SJER
+DSM_SJER <- raster("data/NEON-DS-Airborne-Remote-Sensing/SJER/DSM/SJER_dsmCrop.tif")
+
+DSM_SJER_df <- raster::as.data.frame(DSM_SJER_df, xy = TRUE)
+
+# DTM data for SJER
+DTM_SJER <- raster("data/NEON-DS-Airborne-Remote-Sensing/SJER/DTM/SJER_dtmCrop.tif")
+
+DTM_SJER_df <- raster::as.data.frame(DTM_SJER, xy = TRUE)
 ```
 
 > ## Things You’ll Need To Complete This Episode
@@ -69,7 +79,8 @@ buildings, etc. with the influence of ground elevation removed.
 
 ### Load the Data
 For this episode, we will use the DTM and DSM from the
-NEON Harvard Forest Field site,
+NEON Harvard Forest Field site and San Joaquin Experimental
+Range,
 which we already have loaded from previous episodes.
 
 > ## Exercise

--- a/_episodes_rmd/06-vector-open-shapefile-in-r.Rmd
+++ b/_episodes_rmd/06-vector-open-shapefile-in-r.Rmd
@@ -25,6 +25,7 @@ library(raster)
 library(rgdal)
 library(ggplot2)
 library(dplyr)
+library(sf)
 ```
 
 > ## Things You’ll Need To Complete This Episode
@@ -137,7 +138,7 @@ data to a dataframe before plotting with `ggplot`.
 We're going to customize our boundary plot by setting the 
 size, color, and fill for our plot: 
 
-``` {r plot-shapefile}
+```{r plot-shapefile}
 ggplot() + 
   geom_sf(data = aoi_boundary_HARV, size = 3, color = "black", fill = "cyan1") + 
   ggtitle("AOI Boundary Plot")

--- a/_episodes_rmd/07-vector-shapefile-attributes-in-r.Rmd
+++ b/_episodes_rmd/07-vector-shapefile-attributes-in-r.Rmd
@@ -64,7 +64,7 @@ of the object.
 * `st_crs()` - The CRS (spatial projection) of the data.
 
 We started to explore our `point_HARV` object in the previous episode.
-To see a summary of all of the metadata associated with our `point_HARV` object, we can view the object itself.
+To see a summary of all of the metadata associated with our `point_HARV` object, we can view the object with `View(point_HARV)` or print a summary of the object itself to the console.
 
 ```{r view-object}
 point_HARV
@@ -163,7 +163,10 @@ ggplot() +
 ```
 
 There are two features in our footpaths subset. Why does the plot look like there is only one feature? Let's adjust the colors used in our plot. If we have 2 features in our vector
-object, we can plot each using a unique color by assigning a column name to the color aesthetic (`color =`). We use the syntax `aes(color = )` to do this.
+object, we can plot each using a unique color by assigning a column name to the color aesthetic (`color =`). We use the syntax `aes(color = )` to do this. We can 
+also alter the deault line thickness by using the `size = ` parameter, as the 
+default value of 0.5 can be hard to see. Note that size is placed outside of the 
+`aes()` function, as we are not connecting line thickness to a data variable.
 
 ```{r plot-subset-shapefile-unique-colors }
 ggplot() + 
@@ -237,7 +240,7 @@ Note in the above example we have
 First we will check how many unique levels our
 factor has:
 
-``` {r palette-and-plot}
+```{r palette-and-plot}
 levels(lines_HARV$TYPE)
 ```
 
@@ -245,43 +248,37 @@ Then we can create a pallet of four colors, one for each
 feature in our vector object.
 
 ```{r}
-roadColors <- c("blue", "green", "grey", "purple")[lines_HARV$TYPE]
+roadColors <- c("blue", "green", "grey", "purple")
 ```
 
 We can tell `ggplot` to use these colors when we plot the data.
 
 ```{r}
 ggplot() +
-  geom_sf(data = lines_HARV, aes(color = roadColors)) + 
+  geom_sf(data = lines_HARV, aes(color = TYPE)) + 
+    scale_color_manual(values = roadColors) +
+    labs(color = 'Road Type') +
   ggtitle("NEON Harvard Forest Field Site", subtitle = "Roads & Trails")
 ```
 
 ### Adjust Line Width
-We can also adjust the width of our plot lines using the `size` argument. 
-We can set all lines to be thicker or thinner using `size = `.
-
-```{r adjust-line-width}
-ggplot() + 
-  geom_sf(data = lines_HARV, aes(color = roadColors, size = 3)) + 
-  ggtitle("NEON Harvard Forest Field Site", subtitle = "Roads & Trails - Thick lines")
-```
-
-If we want a unique line width for each factor level or attribute category
+We adjusted line width universally earlier. If we want a unique line width for each factor level or attribute category
 in our spatial object, we can use the same syntax that we used for colors, above.
-
-`size = c("widthOne", "widthTwo", "widthThree")[object$factor]`
 
 We already know that we have four different `TYPE` levels in the lines_HARV object, so we will set four different line widths.
 
 ```{r line-width-unique }
-lineWidths <- (c(1, 2, 3, 4))[lines_HARV$TYPE]
+lineWidths <- c(1, 2, 3, 4)
 ```
 
 We can use those line widths when we plot the data.
 
 ```{r}
 ggplot() +
-  geom_sf(data = lines_HARV, aes(color = roadColors, size = lineWidths)) + 
+  geom_sf(data = lines_HARV, aes(color = TYPE, size = TYPE)) + 
+    scale_color_manual(values = roadColors) +
+    labs(color = 'Road Type') +
+    scale_size_manual(values = lineWidths) +
   ggtitle("NEON Harvard Forest Field Site", subtitle = "Roads & Trails - Line width varies")
 ```
 
@@ -315,14 +312,15 @@ Note that we could also use `aes(size = TYPE)` to tie the line thickness to the 
 > > levels to the desired thickness.
 > >
 > > ```{r}
-> > lineWidth <- c(1, 3, 2, 6)[lines_HARV$TYPE]
+> > lineWidth <- c(1, 3, 2, 6)
 > > ```
 > >
 > > Now we can create our plot.
 > >
 > > ```{r}
 > > ggplot() +
-> >   geom_sf(data = lines_HARV, size = lineWidth) +
+> >   geom_sf(data = lines_HARV, aes(size = TYPE)) +
+> >   scale_size_manual(values = lineWidth) +
 > >   ggtitle("NEON Harvard Forest Field Site", subtitle = "Roads & Trails - Line width varies")
 > > ```
 > {: .solution}
@@ -368,10 +366,6 @@ ggplot() +
   ggtitle("NEON Harvard Forest Field Site", 
           subtitle = "Roads & Trails - Modified Legend")
 ```
-
-We can modify the colors used to plot our lines by creating a new color vector directly in the plot code rather than creating a separate object.
-
-`col = (newColors)[lines_HARV$TYPE]`
 
 ```{r plot-different-colors}
 newColors <- c("springgreen", "blue", "magenta", "orange")

--- a/_episodes_rmd/08-vector-plot-shapefiles-custom-legend.Rmd
+++ b/_episodes_rmd/08-vector-plot-shapefiles-custom-legend.Rmd
@@ -37,7 +37,7 @@ lines_HARV <- st_read("data/NEON-DS-Site-Layout-Files/HARV/HARV_roads.shp")
 point_HARV <- st_read("data/NEON-DS-Site-Layout-Files/HARV/HARVtower_UTM18N.shp")
 CHM_HARV <- raster("data/NEON-DS-Airborne-Remote-Sensing/HARV/CHM/HARV_chmCrop.tif")
 CHM_HARV_df <- raster::as.data.frame(CHM_HARV, xy = TRUE)
-roadColors <- c("blue", "green", "grey", "purple")[lines_HARV$TYPE]
+roadColors <- c("blue", "green", "grey", "purple")
 ```
 
 > ## Things You’ll Need To Complete This Episode
@@ -84,8 +84,6 @@ ggplot() +
 Next, let's build a custom legend using the symbology (the colors and symbols) that we used to create the plot above. For example, it might be good if the lines were symbolized as lines. In the previous episode, you may have noticed that the default legend behaviour for `geom_sf` is to draw a 'patch' for each legend entry. If you want the legend to draw lines or points, you need to add an instruction to the `geom_sf` call - in this case, `show.legend = 'line'`. 
 
 ```{r}
-roadColors <- c("blue", "green", "grey", "purple")[lines_HARV$TYPE]
-
 ggplot() + 
   geom_sf(data = aoi_boundary_HARV, fill = "grey", color = "grey93") +
   geom_sf(data = lines_HARV, aes(color = TYPE), show.legend = "line", size = 1) +
@@ -102,7 +100,7 @@ ggplot() +
   geom_sf(data = aoi_boundary_HARV, fill = "grey", color = "grey93") +
   geom_sf(data = point_HARV, aes(fill = Sub_Type)) +
   geom_sf(data = lines_HARV, aes(color = TYPE), show.legend = "line", size = 1) + 
-  scale_color_manual(values = road_palette, name = "Line Type") + 
+  scale_color_manual(values = roadColors, name = "Line Type") + 
   scale_fill_manual(values = "black", name = "Tower Location") + 
   ggtitle("NEON Harvard Forest Field Site")
 ```
@@ -120,7 +118,7 @@ ggplot() +
  geom_sf(data = aoi_boundary_HARV, fill = "grey", color = "grey93") +
  geom_sf(data = point_HARV, aes(fill = Sub_Type), shape = 15) +
  geom_sf(data = lines_HARV, aes(color = TYPE), show.legend = "line", size = 1) +
- scale_color_manual(values = road_palette, name = "Line Type") +
+ scale_color_manual(values = roadColors, name = "Line Type") +
  scale_fill_manual(values = "black", name = "Tower Location") +
  ggtitle("NEON Harvard Forest Field Site")
 ```

--- a/_episodes_rmd/14-extract-ndvi-from-rasters-in-r.Rmd
+++ b/_episodes_rmd/14-extract-ndvi-from-rasters-in-r.Rmd
@@ -232,6 +232,8 @@ class(avg_NDVI_HARV$Date)
 > > ```
 > > 
 > > Now we will create our Julian day column
+> > 
+> > ```{r}
 > > julianDays_SJER <- gsub("X|_SJER_ndvi_crop", "", row.names(avg_NDVI_SJER))
 > > origin <- as.Date("2011-01-01")
 > > avg_NDVI_SJER$julianDay <- as.integer(julianDays_SJER)


### PR DESCRIPTION
This PR covers the following fixes:

- Adds keypoints for episode 2
- Fixes hillshade layered plot in episode 4 (#229)
- Imports needed SJER data at beginning of episode 4
- Loads sf library at beginning of episode 6
- Re-do fixes to legends in episode 7 and 8 (these were originally fixed by @obrl-soil, but I messed up the merge conflicts and undid a few of them)
- Fix formatting of exercise code in episode 14 - this resolves several error messages later in the episode